### PR TITLE
Make slapd run as PID 1

### DIFF
--- a/docker/ldap/Dockerfile
+++ b/docker/ldap/Dockerfile
@@ -21,10 +21,11 @@ COPY bootstrap.ldif /etc/ldap/
 
 COPY slapd.conf /etc/ldap/
 
-CMD slapadd -c -n1 -l /etc/ldap/bootstrap.ldif -f /etc/ldap/slapd.conf; \
-		chown -R openldap:openldap /var/lib/ldap /etc/ldap; \
-		slapd \
-			-d acl,config,filter,stats,conns \
-			-u openldap \
-			-g openldap \
-			-f /etc/ldap/slapd.conf
+RUN slapadd -c -n1 -l /etc/ldap/bootstrap.ldif -f /etc/ldap/slapd.conf
+RUN chown -R openldap:openldap /var/lib/ldap /etc/ldap
+
+CMD ["slapd", \
+			"-d", "acl,config,filter,stats,conns", \
+			"-u", "openldap", \
+			"-g", "openldap", \
+			"-f", "/etc/ldap/slapd.conf"]


### PR DESCRIPTION
After this commit slapd will be shutdown properly (and faster) on
`docker stop CONTAINER` and won't be killed anymore after 10 seconds.

Before this commit slapd did not start as PID 1 so all
signals (TERM, HUP, ...) were ignored.
